### PR TITLE
feat: v1 of badge subgraph

### DIFF
--- a/subgraph/schema.graphql
+++ b/subgraph/schema.graphql
@@ -69,15 +69,27 @@ type ConfigPlayer @entity {
   player: Player!
   gamesStarted: Int!
   gamesFinished: Int!
+  bestTime: Arena # stores the top time
   wins: Int!
   losses: Int!
   elo: Int!
+  badge: Badge
+  # Non-competitive Badges
 }
 
 type Blocklist @entity {
   id: ID!
   destId: String!
   srcId: String!
+}
+
+type Badge @entity {
+  id: ID!
+  configPlayer: ConfigPlayer!
+  startYourEngine: Boolean!
+  nice: Boolean!,
+  based: Boolean!,
+  ouch: Boolean!
 }
 
 type ArenaConfig @entity {

--- a/subgraph/src/helpers/badges.ts
+++ b/subgraph/src/helpers/badges.ts
@@ -1,0 +1,34 @@
+import { Arena, ArenaPlayer, Badge, ConfigPlayer } from '../../generated/schema';
+
+const NICE = 69;
+const BASED = 420;
+const OUCH = 24 * 60 * 60;
+const START_ENGINE = 1;
+
+export interface BadgeItems {
+  startYourEngine: bool;
+  nice: bool;
+  based: bool;
+  ouch: bool;
+}
+export function updateBadge(
+  allTimeBadges: Badge,
+  arena: Arena,
+  arenaPlayer: ArenaPlayer,
+  configPlayer: ConfigPlayer
+): void {
+  // Only update allTimeBadges if condition is met
+  if (configPlayer.gamesFinished == START_ENGINE) {
+    allTimeBadges.startYourEngine = true;
+  }
+  if (arenaPlayer.moves == NICE) {
+    allTimeBadges.nice = true;
+  }
+  if (arenaPlayer.moves == BASED) {
+    allTimeBadges.based = true;
+  }
+  if (arena.duration > OUCH) {
+    allTimeBadges.ouch = true;
+  }
+  allTimeBadges.save();
+}

--- a/subgraph/src/helpers/badges.ts
+++ b/subgraph/src/helpers/badges.ts
@@ -1,5 +1,4 @@
 import { Arena, ArenaPlayer, Badge, ConfigPlayer } from '../../generated/schema';
-import { CONTRACT_ADDRESS } from '@darkforest_eth/contracts';
 
 import { NICE, BASED, OUCH, START_ENGINE } from './constants';
 

--- a/subgraph/src/helpers/badges.ts
+++ b/subgraph/src/helpers/badges.ts
@@ -1,9 +1,7 @@
 import { Arena, ArenaPlayer, Badge, ConfigPlayer } from '../../generated/schema';
+import { CONTRACT_ADDRESS } from '@darkforest_eth/contracts';
 
-const NICE = 69;
-const BASED = 420;
-const OUCH = 24 * 60 * 60;
-const START_ENGINE = 1;
+import { NICE, BASED, OUCH, START_ENGINE } from './constants';
 
 export interface BadgeItems {
   startYourEngine: bool;

--- a/subgraph/src/helpers/constants.ts
+++ b/subgraph/src/helpers/constants.ts
@@ -2,3 +2,8 @@ export const K_FACTOR = 32;
 export const DEFAULT_ELO = 1200;
 export const NO_TEAM = 0;
 export const MAX_INT_32 = 2147483647 - 1;
+
+export const NICE = 69;
+export const BASED = 420;
+export const OUCH = 24 * 60 * 60;
+export const START_ENGINE = 1;

--- a/subgraph/src/helpers/utils.ts
+++ b/subgraph/src/helpers/utils.ts
@@ -9,6 +9,7 @@ import {
   ArenaConfig,
   ArenaPlanet,
   ArenaPlayer,
+  Badge,
   Blocklist,
   ConfigPlayer,
   Player,
@@ -287,4 +288,13 @@ export function loadArenaPlayerInfo(key: Address): DarkForest__arenaPlayersResul
   } else {
     return result.value;
   }
+}
+
+export function loadBadge(id: string): Badge {
+  const entity = Badge.load(id);
+  if (!entity) {
+    log.error('attempting to load unkown Badge: {}', [id]);
+    throw new Error();
+  }
+  return entity;
 }


### PR DESCRIPTION
1. Badges are now entities in the subgraph
2. ConfigPlayer has a bestTime field, which links to the Arena where the player got the best time.

To test
- [x]  Start a local subgraph (yarn start:subgraph)
- [x]  Finish one grand prix race in client
- [x]  Go to http://localhost:8000/subgraphs/name/df and enter the following

```js
query
  {
    configPlayers(
      where: {configHash_in: ["0xe8c09c646e1c9228918754437a7130a30e4837b21689b51dfd67a8ecf55ebd6e","0x88f6a4430a1723523d420e1320599408c4627e573debe7dd96897c9736d739d0"]}
    ) {
      id
      address
      gamesStarted
      bestTime {
        winners(first:1) {
          moves
        }
        duration
      }
      configHash
      badge {
        id
        based
        ouch
        startYourEngine
        nice
			}
    }
  }
```
 
<img width="413" alt="Screen Shot 2022-08-19 at 4 49 37 PM" src="https://user-images.githubusercontent.com/42984734/185704970-fd0f2aca-0d2a-49b4-bcd1-cd94307c674f.png">

Confirm output looks something like this ^^ 